### PR TITLE
Mark SpirVTasks as a development dependency.

### DIFF
--- a/vkChess.net.csproj
+++ b/vkChess.net.csproj
@@ -33,7 +33,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="VkCrowWindow" Version="0.3.8" />
-		<PackageReference Include="SpirVTasks" Version="0.1.45" />
+		<PackageReference Include="SpirVTasks" Version="0.1.45" PrivateAssets="all" />
 		<PackageReference Include="vke.EnvironmentPipeline" Version="0.2.2-beta" />
 		<PackageReference Include="vke.gltfLoader" Version="0.2.2-beta" />
 	</ItemGroup>


### PR DESCRIPTION
SpirVTasks does not need to be included in the build output. Marking it as a development dependency reduces the app's size.